### PR TITLE
Downscaled Ruby Version to 3.2.2

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.2.2'
           bundler-cache: true
       - name: Set up database schema
         run: bin/rails db:schema:load
@@ -42,7 +42,7 @@ jobs:
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.2.2'
           bundler-cache: true
       - name: Security audit dependencies
         run: bin/bundler-audit --update


### PR DESCRIPTION
Both workflow jobs are failing due to the Rubyt 3.3.0 version being used. Replaced 3.3.0 with Ruby 3.2.2 to test the effect of a Github Actions workflow advised Ruby version to use.