### PR TITLE
Puma Version Updated to 1.5.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "rails", "~> 7.1.3"
 gem "sprockets-rails"
 
 # Use postgresql as the database for Active Record
-gem "pg", "~> 1.1"
+gem "pg", "~> 1.5.4"
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,7 +257,7 @@ DEPENDENCIES
   debug
   importmap-rails
   jbuilder
-  pg (~> 1.1)
+  pg (~> 1.5.4)
   puma (>= 5.0)
   rails (~> 7.1.3)
   selenium-webdriver


### PR DESCRIPTION
Updated the Puma gem to the latest version as it was on 1.1 (last version of this was 1.1.4 release in January 2019).

Tested locally following the update, db reset and browsing db seed in the application mailer in localhost, works fine as per previous to the update.