### PR TITLE
Sidekiq Setup with a First User job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# Initially for backgrouind user jobs
+gem "sidekiq"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,8 @@ GEM
     rake (13.1.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
+    redis-client (0.20.0)
+      connection_pool
     regexp_parser (2.9.0)
     reline (0.4.2)
       io-console (~> 0.5)
@@ -211,6 +213,11 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sidekiq (7.2.2)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.19.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -261,6 +268,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.3)
   selenium-webdriver
+  sidekiq
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails s
+worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,8 @@ class UsersController < ApplicationController
     @user = User.create(user_params)
     UserMailer.with(user: @user).welcome_email.deliver_later
 
+    UserInsertionWorker.perform_async(users)
+
     redirect_to @user
   end
 end

--- a/app/sidekiq/user_insertion_job.rb
+++ b/app/sidekiq/user_insertion_job.rb
@@ -1,0 +1,9 @@
+class UserInsertionWorker
+  include Sidekiq::Worker
+
+  def perform(users)
+    users.each do |user|
+      User.create!(name: user.name, email: user.email)
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module RailsJunction
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
+    config.active_job.queue_adapter = :sidekiq
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.

--- a/test/jobs/user_insertion_job_test.rb
+++ b/test/jobs/user_insertion_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserInsertionJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/sidekiq/user_insertion_job_test.rb
+++ b/test/sidekiq/user_insertion_job_test.rb
@@ -1,0 +1,6 @@
+require 'test_helper'
+class UserInsertionJobTest < Minitest::Test
+  def test_example
+    skip "add some examples to (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
Installed Sidekiq 7.2.2 and activated it via adding a confirmation line to the application.rb file that sidekiq will be the job adapter being used from this point onwards.

Also setup the first user job in a Sidekiq user insertion class (placeholder for now).

Users controller create action updated with the new Sidekiiq user insertion job method.

Created a Procfile.dev file containing instructions for Sidekiq running in a local development environment.

Test user insertion job is a leftover from original Rails ActiveJob setup, will be removed in next commit.