### PR TITLE
Bundler Audit Added and Ran to Check for Vulnerable Gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,11 @@ gem 'sidekiq-failures'
 # For the development environment with Sidekiq
 gem "foreman"
 
+
+
+# For checking existing gem versions and for vulnerabilities
+gem 'bundler-audit'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,9 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bundler-audit (0.9.1)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     capybara (3.40.0)
       addressable
       matrix
@@ -261,6 +264,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bundler-audit
   capybara
   debug
   foreman


### PR DESCRIPTION
Installed bundler-audit to check the Gemfile.lock for any
 vulnerable gems.

Ran several bundler-audit commands and did not locate any vulnerable gems.

Also updated the rubygems version to 3.5.6 locally.