### PR TITLE
Country Model and DB Relations for Country setup

### DIFF
--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,0 +1,2 @@
+class Country < ApplicationRecord
+end

--- a/db/migrate/20240226193914_create_countries.rb
+++ b/db/migrate/20240226193914_create_countries.rb
@@ -1,0 +1,10 @@
+class CreateCountries < ActiveRecord::Migration[7.1]
+  def change
+    create_table :countries do |t|
+      t.string :name
+      t.string :code
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_25_174703) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_26_193914) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "cities", force: :cascade do |t|
     t.string "name"
     t.integer "population"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "countries", force: :cascade do |t|
+    t.string "name"
+    t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/fixtures/countries.yml
+++ b/test/fixtures/countries.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  code: MyString
+
+two:
+  name: MyString
+  code: MyString

--- a/test/models/country_test.rb
+++ b/test/models/country_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CountryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Cities were previously setup to belong to a country, this branch and in particular this commit and PR deals with the establishment of the country model and its incorporation into the database.

The Country model was generated along with related country model files (test and yml files) to use a string of name for the country name and a string of code for the ISO 3166-1 country codes.