### PR TITLE
Ffaker gem added, Seeds Created for Cities and a Junction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem "foreman"
 gem 'bundler-audit'
 
 group :development, :test do
+  gem "ffaker"
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
+    ffaker (2.23.0)
     foreman (0.87.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -267,6 +268,7 @@ DEPENDENCIES
   bundler-audit
   capybara
   debug
+  ffaker
   foreman
   importmap-rails
   jbuilder

--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -1,5 +1,13 @@
 class CitiesController < ApplicationController
+  def create
+    @city = City.new(city_params)
+  end
+  
   def show
     @city = City.find(params[:id])
+  end
+
+  def index
+    @cities = City.all
   end
 end

--- a/app/controllers/junctions_controller.rb
+++ b/app/controllers/junctions_controller.rb
@@ -1,0 +1,11 @@
+class JunctionsController < ApplicationController
+  def create
+    @junction = Junction.new(junction_params)
+  end
+
+  private
+
+  def junction_params
+    params.require(:junction).permit(:name, :location)
+  end
+end

--- a/app/helpers/junctions_helper.rb
+++ b/app/helpers/junctions_helper.rb
@@ -1,0 +1,2 @@
+module JunctionsHelper
+end

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,5 +1,7 @@
 class City < ApplicationRecord
   has_many :junctions
 
-  belongs_to :country
+  # belongs_to :country
+
+  validates :name, presence: true
 end

--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -1,0 +1,17 @@
+<h1>Cities with Junctions</h1>
+<ul>
+  <% @cities.each do |city| %>
+    <li><%= city.name %></li>
+    <% if city.has_junctions? %>
+       <ul>
+        <% city.junctions.each do |junction| %>
+          <li>Junction: <%= junction.name %></li>
+          <!-- Add more details about the junction if needed -->
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+</ul>
+
+<h1><%= @city.name %></h1>
+<p>Population: <%= @city.population %></p>

--- a/app/views/junctions/index.html.erb
+++ b/app/views/junctions/index.html.erb
@@ -1,0 +1,6 @@
+<h2>Junctions:</h2>
+<ul>
+  <% @city.junctions.each do |junction| %>
+    <li><%= junction.name %> (Located in: <%= junction.location %>)</li>
+  <% end %>
+</ul>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,11 +1,11 @@
 <h1>Homepage</h1>
 
-<h1><%= @city.name %></h1>
-<p>Population: <%= @city.population %></p>
+<h1>Random City</h1>
+<% random_city = City.all.sample %>
 
-<h2>Junctions:</h2>
-<ul>
-  <% @city.junctions.each do |junction| %>
-    <li><%= junction.name %> (Located in: <%= junction.location %>)</li>
-  <% end %>
-</ul>
+<% if random_city %>
+  <p>Name: <%= random_city.name %></p>
+  <p>Population: <%= random_city.population %></p>
+<% else %>
+  <p>No cities found.</p>
+<% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,10 +8,31 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
+require 'ffaker'
+
+City.destroy_all
+User.destroy_all
+
 User.create!(
   name: "John Smith",
   email: "john.smith@example.com"
 )
 
-City.create(name: 'Metropolis', population: 100000)
-City.last.junctions.create(name: 'Central Square', location: 'Downtown')
+10.times do |i|
+  city = City.create(name: FFaker::Address.city, population: rand(1000..1_000_000))
+  if city.persisted?
+    puts "City #{i + 1}: #{city.name} created successfully!"
+  else
+    puts "City #{i + 1}: Error creating city - #{city.errors.full_messages.join(', ')}"
+  end
+end
+
+Junction.create(name: 'Central Square', location: 'Downtown')
+
+last_city = City.last
+if last_city
+  last_city.junctions.create(name: 'Central Square', location: 'Downtown')
+  puts "Junction created successfully for the last city: #{last_city.name}"
+else
+  puts "No cities found. Please create some cities first."
+end

--- a/test/controllers/junctions_controller_test.rb
+++ b/test/controllers/junctions_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class JunctionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Ffaker gem added to call on fake cities and other future entities.

Added actions at the start of the seed file to destroy all existing cities and users ahead of going through the seed process to avoid a growing amount of duplicate and excess seeds. Not implemented the same for junction seeds as not creating many junction seeds as of now.

Homepage adjusted to call on a random city from the newly added Ffaker gem seeds.

City model has the belongs_to :country commented out until it is resolved as to its effect preventing seeds in the current db/seeds.rb file from being created. Have also included a validation of the name attribute for the city model.

Junction created individually to test that junctions can seed succesfully independently from being contained within a city.

Views setup for junctions and cities, just basic code for now, not linking to it yet until navigation and/or layout design has been finalised.

Junctions controller and several controller actions created within it, cities controller also has similar controller actions now implemented.