### PR TITLE
Links Added to Cities and Junctions, Views Readjusted

### DIFF
--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -2,7 +2,7 @@ class CitiesController < ApplicationController
   def create
     @city = City.new(city_params)
   end
-  
+
   def show
     @city = City.find(params[:id])
   end

--- a/app/controllers/junctions_controller.rb
+++ b/app/controllers/junctions_controller.rb
@@ -3,6 +3,10 @@ class JunctionsController < ApplicationController
     @junction = Junction.new(junction_params)
   end
 
+  def index
+    
+  end
+
   private
 
   def junction_params

--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -1,17 +1,8 @@
 <h1>Cities with Junctions</h1>
+
 <ul>
   <% @cities.each do |city| %>
     <li><%= city.name %></li>
-    <% if city.has_junctions? %>
-       <ul>
-        <% city.junctions.each do |junction| %>
-          <li>Junction: <%= junction.name %></li>
-          <!-- Add more details about the junction if needed -->
-        <% end %>
-      </ul>
-    <% end %>
+    <li>Population: <%= city.population %></li>
   <% end %>
 </ul>
-
-<h1><%= @city.name %></h1>
-<p>Population: <%= @city.population %></p>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -9,3 +9,7 @@
 <% else %>
   <p>No cities found.</p>
 <% end %>
+
+<%= link_to "All Junctions", junctions_path %>
+
+<%= link_to "All Cities", cities_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,6 @@ Rails.application.routes.draw do
   resources :cities do
     resources :junctions
   end
+
+  resources :junctions
 end


### PR DESCRIPTION
Links now exist from the homepage to the index pages for cities and junctions.

Added junctions outside of being nested inside the cities resources routes to allow the junctions path to run succesfully.

Cut down on excess view code for the index pages of both cities and junctions, displays the relevant seeds generated in the views for each.

Also cut down on both of the cities and junctions controller index actions to not set any rules for what the index should include, just to allow seeds to generate in the frontend.