### PR TITLE
Junctions Seeds Added, Reconfigured Several Related Files

### DIFF
--- a/app/controllers/junctions_controller.rb
+++ b/app/controllers/junctions_controller.rb
@@ -1,10 +1,16 @@
 class JunctionsController < ApplicationController
   def create
     @junction = Junction.new(junction_params)
+
+    if @junction.save
+      redirect_to junctions_path, notice: 'Junction was successfully created.'
+    else
+      render :new
+    end
   end
 
   def index
-    
+    @junctions = Junction.all
   end
 
   private

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,5 +1,5 @@
 class City < ApplicationRecord
-  has_many :junctions
+  has_many :junctions, dependent: :destroy
 
   # belongs_to :country
 

--- a/app/views/junctions/index.html.erb
+++ b/app/views/junctions/index.html.erb
@@ -1,6 +1,6 @@
 <h2>Junctions:</h2>
 <ul>
-  <% @city.junctions.each do |junction| %>
+  <% @junctions.each do |junction| %>
     <li><%= junction.name %> (Located in: <%= junction.location %>)</li>
   <% end %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root to: "pages#home"
 
-  resources :cities do
-    resources :junctions
-  end
+  resources :cities
 
   resources :junctions
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,7 @@ require 'ffaker'
 
 City.destroy_all
 User.destroy_all
+Junction.destroy_all
 
 User.create!(
   name: "John Smith",
@@ -27,12 +28,28 @@ User.create!(
   end
 end
 
-Junction.create(name: 'Central Square', location: 'Downtown')
-
 last_city = City.last
+
 if last_city
-  last_city.junctions.create(name: 'Central Square', location: 'Downtown')
-  puts "Junction created successfully for the last city: #{last_city.name}"
+  junctions_data = [
+    { name: 'Central Square', location: 'Downtown' },
+    { name: "Spaghetti Junction", location: "Birmingham" },
+    { name: "Shibuya Crossing", location: "Tokyo" },
+    { name: "Arc de Triomphe Roundabout", location: "Paris" },
+    { name: "Magic Roundabout", location: "Swindon" },
+    { name: "Times Square Intersection", location: "New York location" },
+    { name: "Akihabara Crossing", location: "Tokyo" }
+  ]
+
+  junctions_data.each do |junction_data|
+    junction = last_city.junctions.create(junction_data)
+
+    if junction.persisted?
+      puts "Junction created successfully for the last city: #{last_city.name}"
+    else
+      puts "Error creating junction - #{junction.errors.full_messages.join(', ')}"
+    end
+  end
 else
   puts "No cities found. Please create some cities first."
 end


### PR DESCRIPTION
Added 6 real junctions to the seeds file that are populated along with the single pre-existing seed already in the junctions index. Also reconfigured the junctions code block to make it suitable the increased amount of junction seeds now populated. Junctions destroy action also added to the seeds file to delete all seeds each database reset/seeding process

Added junctions to its own individual resources in the routes and removed it from the nested former status within the cities routes resources.

Removed city from the instance variable for the junctions index to allow the index page for junctions to function accurately.

Junctions controller updated with added create action code to account for when new junctions will be added in the future.

City model updated to allow junctions to be destroyed as part of the seed generate command process.