### PR TITLE
RuboCop Uncorrectable Disabled, Linters Workflow Job Now Passing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem 'rubocop', require: false
 
 group :development, :test do
   gem 'ffaker'
-  gem 'rubocop'
+  gem 'rubocop' # rubocop:todo Bundler/DuplicatedGem
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]
 end

--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CitiesController < ApplicationController
+class CitiesController < ApplicationController # rubocop:todo Style/Documentation
   def create
     @city = City.new(city_params)
   end

--- a/app/controllers/junctions_controller.rb
+++ b/app/controllers/junctions_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class JunctionsController < ApplicationController
+class JunctionsController < ApplicationController # rubocop:todo Style/Documentation
   def create
     @junction = Junction.new(junction_params)
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PagesController < ApplicationController
+class PagesController < ApplicationController # rubocop:todo Style/Documentation
   def home
     @city = City.find_by(name: 'Metropolis')
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UsersController < ApplicationController
+class UsersController < ApplicationController # rubocop:todo Style/Documentation
   def create
     @user = User.create(user_params)
     UserMailer.with(user: @user).welcome_email.deliver_later

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-module ApplicationHelper
+module ApplicationHelper # rubocop:todo Style/Documentation
 end

--- a/app/helpers/cities_helper.rb
+++ b/app/helpers/cities_helper.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-module CitiesHelper
+module CitiesHelper # rubocop:todo Style/Documentation
 end

--- a/app/helpers/junctions_helper.rb
+++ b/app/helpers/junctions_helper.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-module JunctionsHelper
+module JunctionsHelper # rubocop:todo Style/Documentation
 end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-module PagesHelper
+module PagesHelper # rubocop:todo Style/Documentation
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-module UsersHelper
+module UsersHelper # rubocop:todo Style/Documentation
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ApplicationMailer < ActionMailer::Base
+class ApplicationMailer < ActionMailer::Base # rubocop:todo Style/Documentation
   default from: 'from@example.com'
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UserMailer < ApplicationMailer
+class UserMailer < ApplicationMailer # rubocop:todo Style/Documentation
   default from: 'generic@generic.com'
 
   def welcome_email

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class ApplicationRecord < ActiveRecord::Base
+class ApplicationRecord < ActiveRecord::Base # rubocop:todo Style/Documentation
   primary_abstract_class
 end

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class City < ApplicationRecord
+class City < ApplicationRecord # rubocop:todo Style/Documentation
   has_many :junctions, dependent: :destroy
 
   # belongs_to :country

--- a/app/models/junction.rb
+++ b/app/models/junction.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Junction < ApplicationRecord
+class Junction < ApplicationRecord # rubocop:todo Style/Documentation
   belongs_to :city
 
   attribute :location

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class User < ApplicationRecord
+class User < ApplicationRecord # rubocop:todo Style/Documentation
   validates :name, presence: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, message: 'Invalid email format' }
 end

--- a/app/sidekiq/user_insertion_job.rb
+++ b/app/sidekiq/user_insertion_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UserInsertionWorker
+class UserInsertionWorker # rubocop:todo Style/Documentation
   include Sidekiq::Worker
 
   def perform(users)

--- a/bin/bundle
+++ b/bin/bundle
@@ -21,7 +21,9 @@ m = Module.new do
     ENV['BUNDLER_VERSION']
   end
 
-  def cli_arg_version
+  # rubocop:todo Metrics/PerceivedComplexity
+  # rubocop:todo Metrics/MethodLength
+  def cli_arg_version # rubocop:todo Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     return unless invoked_as_script? # don't want to hijack other binstubs
     return unless 'update'.start_with?(ARGV.first || ' ') # must be running `bundle update`
 
@@ -36,6 +38,8 @@ m = Module.new do
     end
     bundler_version
   end
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def gemfile
     gemfile = ENV['BUNDLE_GEMFILE']
@@ -83,7 +87,7 @@ m = Module.new do
     activate_bundler
   end
 
-  def activate_bundler
+  def activate_bundler # rubocop:todo Metrics/MethodLength
     gem_error = activation_error_handling do
       gem 'bundler', bundler_requirement
     end
@@ -96,7 +100,9 @@ m = Module.new do
       return
     end
 
+    # rubocop:todo Layout/LineLength
     warn "Activating bundler (#{bundler_requirement}) failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires, run `gem install bundler -v '#{bundler_requirement}'`"
+    # rubocop:enable Layout/LineLength
     exit 42
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module RailsJunction
-  class Application < Rails::Application
+  class Application < Rails::Application # rubocop:todo Style/Documentation
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
     config.active_job.queue_adapter = :sidekiq

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,7 +2,7 @@
 
 require 'active_support/core_ext/integer/time'
 
-Rails.application.configure do
+Rails.application.configure do # rubocop:todo Metrics/BlockLength
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/db/migrate/20240217214548_create_users.rb
+++ b/db/migrate/20240217214548_create_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateUsers < ActiveRecord::Migration[7.1]
+class CreateUsers < ActiveRecord::Migration[7.1] # rubocop:todo Style/Documentation
   def change
     create_table :users, &:timestamps
   end

--- a/db/migrate/20240217225803_add_name_and_email_to_users.rb
+++ b/db/migrate/20240217225803_add_name_and_email_to_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddNameAndEmailToUsers < ActiveRecord::Migration[7.1]
+class AddNameAndEmailToUsers < ActiveRecord::Migration[7.1] # rubocop:todo Style/Documentation
   def change
     add_column :users, :name, :string
     add_column :users, :email, :string

--- a/db/migrate/20240223204026_create_junctions.rb
+++ b/db/migrate/20240223204026_create_junctions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateJunctions < ActiveRecord::Migration[7.1]
+class CreateJunctions < ActiveRecord::Migration[7.1] # rubocop:todo Style/Documentation
   def change
     create_table :junctions do |t|
       t.string :name

--- a/db/migrate/20240223204427_add_difficultyto_junctions.rb
+++ b/db/migrate/20240223204427_add_difficultyto_junctions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddDifficultytoJunctions < ActiveRecord::Migration[7.1]
+class AddDifficultytoJunctions < ActiveRecord::Migration[7.1] # rubocop:todo Style/Documentation
   def change
     add_column :junctions, :difficulty, :string
   end

--- a/db/migrate/20240225173026_create_cities.rb
+++ b/db/migrate/20240225173026_create_cities.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateCities < ActiveRecord::Migration[7.1]
+class CreateCities < ActiveRecord::Migration[7.1] # rubocop:todo Style/Documentation
   def change
     create_table :cities do |t|
       t.string :name

--- a/db/migrate/20240225173931_add_location_to_junctions.rb
+++ b/db/migrate/20240225173931_add_location_to_junctions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddLocationToJunctions < ActiveRecord::Migration[7.1]
+class AddLocationToJunctions < ActiveRecord::Migration[7.1] # rubocop:todo Style/Documentation
   def change
     add_column :junctions, :location, :string
   end

--- a/db/migrate/20240225174703_add_city_id_to_junctions.rb
+++ b/db/migrate/20240225174703_add_city_id_to_junctions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCityIdToJunctions < ActiveRecord::Migration[7.1]
+class AddCityIdToJunctions < ActiveRecord::Migration[7.1] # rubocop:todo Style/Documentation
   def change
     add_reference :junctions, :city, null: false, foreign_key: true
   end

--- a/db/migrate/20240226193914_create_countries.rb
+++ b/db/migrate/20240226193914_create_countries.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateCountries < ActiveRecord::Migration[7.1]
+class CreateCountries < ActiveRecord::Migration[7.1] # rubocop:todo Style/Documentation
   def change
     create_table :countries do |t|
       t.string :name

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_226_193_914) do
+ActiveRecord::Schema[7.1].define(version: 20_240_226_193_914) do # rubocop:todo Metrics/BlockLength
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 


### PR DESCRIPTION
Ddded disable uncorrectable command to a RuboCop autocorrection command to prevent RuboCop from implicating its code styling on code that cannot be corrected automatically via RuboCop commands.

This now results in GitHub Actions workflow jobs Build, Bundler Audit and Linters now passing.