### PR TITLE
Added Placeholder for Empty Junction Names in View, Added Links and C…

### DIFF
--- a/app/views/junctions/index.html.erb
+++ b/app/views/junctions/index.html.erb
@@ -1,6 +1,13 @@
-<h2>Junctions:</h2>
+<h1>Junctions:</h1>
+<p>Discover the various junctions in our city:</p>
 <ul>
   <% @junctions.each do |junction| %>
-    <li><%= junction.name %> (Located in: <%= junction.location %>)</li>
+     <li>
+      <strong>Junction Name:</strong> <%= junction.name || 'Junction will appear soon...' %><br>
+      <strong>Location:</strong> <%= junction.location %><br>
+      <strong>City:</strong> <%= junction.city.name %>
+    </li>
   <% end %>
 </ul>
+
+<%= link_to "New Junction", new_junction_path %>

--- a/app/views/junctions/new.html.erb
+++ b/app/views/junctions/new.html.erb
@@ -1,12 +1,13 @@
 <%= simple_form_for @junction do |f| %>
   <div class="mb-3">
-    <%= f.label :location, class: "form-label" %>
-    <%= f.text_field :junction, class: "form-control", placeholder: "Enter a Junction" %>
-    <%= f.text_field :location, class: "form-control", placeholder: "Junction Location" %>
-
+    <%= f.label :junction, class: "form-label" %>
+    <%= f.text_field :junction.name, class: "form-control", placeholder: "Enter a Junction Name" %>
+    <%= f.input :location, class: "form-control", placeholder: "Junction Location" %>
   </div>
 
   <%= f.association :city, label_method: :name, value_method: :id, prompt: "Select a city", class: "form-select" %>
 
   <%= f.submit "Create", class: "btn btn-primary" %>
 <% end %>
+
+<% link_to "Home", root_path %>


### PR DESCRIPTION
…hanged Text

Expression added to the ERB tag for junction names, in the case of created junctions via the new junction form it is not rendering frontend the junction name. Seeds are rendering the junction name frontend, therefore the expression including the pipes to display a fallback message in the index page in the place of the junction name covering for the lack of a rendered junction name. Also the junction name, city and location all now display in the index and for displaying the attributes of individual junction records.

Website navigation is far easier with links to the homepage and new junction form available in the junction new and index pages respectively.

Text added to junctions index to make it more welcoming. 

Also resized the junctions index header from h2 to h1 header text to make it more impactful as the page header.