### PR TITLE
User Sign Up and Confirmations Setup

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,27 @@
+class ConfirmationsController < ApplicationController
+  def create
+    @user = User.find_by(email: params[:user][:email].downcase)
+
+    if @user.present? && @user.unconfirmed?
+      redirect_to root_path, notice: "Check your email for confirmation instructions."
+    else
+      redirect_to new_confirmation_path, alert: "We could not find a user with that email or that email has already been confirmed."
+    end
+  end
+
+  def edit
+    @user = User.find_signed(params[:confirmation_token], purpose: :confirm_email)
+
+    if @user.present?
+      @user.confirm!
+      redirect_to root_path, notice: "Your account has been confirmed."
+    else
+      redirect_to new_confirmation_path, alert: "Invalid token."
+    end
+  end
+
+  def new
+    @user = User.new
+  end
+
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,4 @@
+class StaticPagesController < ApplicationController
+  def home
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,18 +11,17 @@ class UsersController < ApplicationController # rubocop:todo Style/Documentation
 
   def create
     @user = User.new(user_params)
-    UserMailer.with(user: @user).welcome_email.deliver_later
+    UserMailer.with(user: @user).welcome_email
 
-    UserInsertionWorker.perform_async(users)
+    # UserInsertionWorker.perform_async(users)
 
     redirect_to @user
 
     if @user.save
       flash[:notice] = "User created successfully"
-      redirect_to users_path
+      redirect_to users_path, status: :unprocessable_entity
     else
       flash[:alert] = "User not created"
-      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/helpers/confirmations_helper.rb
+++ b/app/helpers/confirmations_helper.rb
@@ -1,0 +1,2 @@
+module ConfirmationsHelper
+end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,0 +1,2 @@
+module StaticPagesHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,9 +3,27 @@
 class User < ApplicationRecord # rubocop:todo Style/Documentation
   before_save :downcase_email
 
+  CONFIRMATION_TOKEN_EXPIRATION = 10.minutes
+
   has_secure_password
   validates :name, presence: true, uniqueness: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP}, presence: true, uniqueness: true
+
+  def confirm!
+    update_columns(confirmed_at: Time.current)
+  end
+
+  def confirmed?
+    confirmed_at.present?
+  end
+
+  def generate_confirmation_token
+    signed_id expires_in: CONFIRMATION_TOKEN_EXPIRATION, purpose: :confirm_email
+  end
+
+  def unconfirmed?
+    !confirmed?
+  end
 
   private
 

--- a/app/views/confirmations/new.html.erb
+++ b/app/views/confirmations/new.html.erb
@@ -1,0 +1,6 @@
+<%= simple_form_for @user, url: confirmations_path do |form| %>
+  <div>
+    <%= form.input :email, required: true, label: "Email" %>
+  </div>
+  <%= form.button :submit, "Confirm Email" %>
+<% end %>

--- a/app/views/shared/_form_errors.html.erb
+++ b/app/views/shared/_form_errors.html.erb
@@ -1,0 +1,7 @@
+<% if object.errors.any? %>
+  <ul>
+    <% object.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,0 +1,2 @@
+<h1>StaticPages#home</h1>
+<p>Find me in app/views/static_pages/home.html.erb</p>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,13 @@
+<%= simple_form_for @user, url: sign_up_path do |form| %>
+  <%= render partial: "shared/form_errors", locals: { object: form.object } %>
+  <div>
+    <%= form.input :email, required: true, label: "Email" %>
+  </div>
+  <div>
+    <%= form.input :password, required: true, label: "Password" %>
+  </div>
+  <div>
+    <%= form.input :password_confirmation, required: true, label: "Confirm Password" %>
+  </div>
+  <%= form.button :submit, "Sign Up" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@
 
 require 'sidekiq/web'
 Rails.application.routes.draw do
+  get 'static_pages/home'
   mount Sidekiq::Web => '/sidekiq'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
@@ -17,4 +18,9 @@ Rails.application.routes.draw do
   resources :junctions
 
   resources :users, only: [:index, :new, :create]
+
+  post "sign_up", to: "users#create"
+  get "sign_up", to: "users#new"
+
+  resources :confirmations, only: [:create, :edit, :new], param: :confirmation_token
 end

--- a/test/controllers/confirmations_controller_test.rb
+++ b/test/controllers/confirmations_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ConfirmationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class StaticPagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get home" do
+    get static_pages_home_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Users can now sign up via the New User link in the user index page,

User controller ran into a render and redirect issue as both cannot be used in a create method, therefore refactored this portion of code to allow user sign ups to occur without this error, will look to revisit this in the future as the code is not completely as intended here.

Commented out Sidekiq job action in the user controller and updated email from deliver later to removing deliver later to allow user accounts and subsequent account and sign up related emails to be sent at the point of sign up and not further down the line.

Updated the routes to take into account the new sign up paths needed and the confirmations resources required.

User model updated to handle user confirmations, including various methods for different points a new user could be at.

Shared folder created and new form_errors partial view created to detail to the prospective new user if there are any errors found during the sign up process.

Confirmations controller generated and related files created from the generation. The controller handles verifying the user after they sign up in order to avoid spam from occurring due to such actions as a massive amount of user sign ups.

Static pages view, controller introduced and view page added to the routes, will look to utilise them soon.

This is the second commit for this user authentication branch and there are at least several points to go until at a stable step for authenticating users.