### PR TITLE
Password Reset Setup, Mailers Created for Password Reset

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,0 +1,52 @@
+class PasswordsController < ApplicationController
+  before_action :redirect_if_authenticated
+
+  def create
+    @user = User.find_by(email: params[:user][:email].downcase)
+    if @user.present?
+      if @user.confirmed?
+        @user.send_password_reset_email!
+        redirect_to root_path, notice: "If that user exists we've sent instructions to their email."
+      else
+        redirect_to new_confirmation_path, alert: "Please confirm your email first."
+      end
+    else
+      redirect_to root_path, notice: "If that user exists we've sent instructions to their email."
+    end
+  end
+
+  def edit
+    @user = User.find_signed(params[:password_reset_token], purpose: :reset_password)
+    if @user.present? && @user.unconfirmed?
+      redirect_to new_confirmation_path, alert: "You must confirm your email before you can sign in."
+    elsif @user.nil?
+      redirect_to new_password_path, alert: "Invalid or expired token."
+    end
+  end
+
+  def new
+  end
+
+  def update
+    @user = User.find_signed(params[:password_reset_token], purpose: :reset_password)
+    if @user
+      if @user.unconfirmed?
+        redirect_to new_confirmation_path, alert: "You must confirm your email before you can sign in."
+      elsif @user.update(password_params)
+        redirect_to login_path, notice: "Sign in."
+      else
+        flash.now[:alert] = @user.errors.full_messages.to_sentence
+        render :edit, status: :unprocessable_entity
+      end
+    else
+      flash.now[:alert] = "Invalid or expired token."
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def password_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
+end

--- a/app/helpers/passwords_helper.rb
+++ b/app/helpers/passwords_helper.rb
@@ -1,0 +1,2 @@
+module PasswordsHelper
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -10,4 +10,11 @@ class UserMailer < ApplicationMailer # rubocop:todo Style/Documentation
 
     mail(to: @user.email, subject: 'Welcome to Rails Junction')
   end
+
+  def password_reset(user, password_reset_token)
+    @user = user
+    @password_reset_token = password_reset_token
+
+    mail to: @user.email, subject: "How to reset your Password"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord # rubocop:todo Style/Documentation
 
   CONFIRMATION_TOKEN_EXPIRATION = 10.minutes
 
+  PASSWORD_RESET_TOKEN_EXPIRATION = 10.minutes
+
   has_secure_password
   validates :name, presence: true, uniqueness: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP}, presence: true, uniqueness: true
@@ -30,6 +32,15 @@ class User < ApplicationRecord # rubocop:todo Style/Documentation
 
   def unconfirmed?
     !confirmed?
+  end
+
+  def generate_password_reset_token
+    signed_id expires_in: PASSWORD_RESET_TOKEN_EXPIRATION, purpose: :reset_password
+  end
+  ...
+  def send_password_reset_email!
+    password_reset_token = generate_password_reset_token
+    UserMailer.password_reset(self, password_reset_token).deliver_now
   end
 
   private

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,0 +1,11 @@
+<%= simple_form_for :user, url: password_path(params[:password_reset_token]), scope: :user, method: :put do |form| %>
+  <div>
+    <%= form.label :password %>
+    <%= form.password_field :password, required: true %>
+  </div>
+  <div>
+    <%= form.label :password_confirmation %>
+    <%= form.password_field :password_confirmation, required: true %>
+  </div>
+  <%= form.submit "Update Password" %>
+<% end %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,0 +1,4 @@
+<%= simple_form_for :user, url: passwords_path, scope: :user do |form| %>
+  <%= form.email_field :email, required: true %>
+  <%= form.submit "Reset Password" %>
+<% end %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,3 @@
+<h1>How to reset your Password</h1>
+
+<%= link_to "Click here to reset your password.", edit_password_url(@password_reset_token) %>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,3 @@
+How to reset your Password
+
+<%= edit_password_url(@password_reset_token) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,4 +27,6 @@ Rails.application.routes.draw do
   get "login", to: "sessions#new"
 
   resources :confirmations, only: [:create, :edit, :new], param: :confirmation_token
+
+  resources :passwords, only: [:create, :edit, :new, :update], param: :password_reset_token
 end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PasswordsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Generated controller and related files for passwords to control the authentication dependent upon if the user is confirmed, required to confirm or expired password authentication token.

Routes updated with inclusion of password resources to handle the redirecting for several CRUD actions password related.

Simple form fields created for new and edit password view pages.

User mailer gained new method to handle password reset, relevant password_reset user mailer html and text ERB files formed to handle the edit path a reset password is required to take.

Similar to user confirmation authentication token being timed at an expiry of 10 minutes, the same has been setup for the newly added password reset token, to ensure users requesting the reset password, in order to prevent unintended accessors from accessing the email beyond the 10 minutes the user has upon submitting the reset password request and setting up their own password.