### PR TITLE
Setup Premise for Crossroads, Including Controller, Routes, Modal and Show pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,20 @@
 @import "bootstrap";
+
+dialog {
+  width: 60vw;
+  margin: auto;
+
+  &::backdrop {
+    background: rgb(133, 118, 118);
+    opacity: 0.4;
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+
+    h2 {
+      flex: 0 1 100%;
+    }
+  }
+}

--- a/app/controllers/crossroads_controller.rb
+++ b/app/controllers/crossroads_controller.rb
@@ -1,0 +1,4 @@
+class CrossroadsController < ApplicationController
+  def show
+  end
+end

--- a/app/helpers/crossroads_helper.rb
+++ b/app/helpers/crossroads_helper.rb
@@ -1,0 +1,2 @@
+module CrossroadsHelper
+end

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="modal"
+export default class extends Controller {
+  connect() {
+    this.element.dataset.action = "modal#show";
+  }
+
+  show(event) {
+    // ...
+  }
+}

--- a/app/views/crossroads/show.html.erb
+++ b/app/views/crossroads/show.html.erb
@@ -1,0 +1,21 @@
+<button
+  data-controller="modal"
+  data-action="modal#show"
+  data-modal-dialog-param="crossroad_modal">
+  Show Crossroad
+</button>
+
+<dialog id="crossroad_modal" aria-labelledby="modal_title">
+  <header>
+    <h2 id="modal_title">
+      Crossroad
+    </h2>
+    <form method="dialog">
+      <button aria-label="close">X</button>
+    </form>
+  </header>
+
+  <p>
+    Lorem ipsum and so forth...
+  </p>
+</dialog>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -21,6 +21,7 @@
             <li><a class="dropdown-item" <%= link_to "All Cities", cities_path %></a></li>
             <li><hr class="dropdown-divider"></li>
             <li><a class="dropdown-item" <%= link_to "Login", login_path %></a></li>
+            <li><a class="dropdown-item" <%= link_to "Crossroads", crossroads_path %></a></li>
           </ul>
         </li>
         <li class="nav-item">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@
 
 require 'sidekiq/web'
 Rails.application.routes.draw do
+  get 'crossroads/show'
   get 'static_pages/home'
   mount Sidekiq::Web => '/sidekiq'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
@@ -19,6 +20,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:index, :new, :create]
 
+  get '/crossroads', to: "crossroads#show"
   post "sign_up", to: "users#create"
   get "sign_up", to: "users#new"
 

--- a/test/controllers/crossroads_controller_test.rb
+++ b/test/controllers/crossroads_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class CrossroadsControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get crossroads_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Generated crossroads controller and crossroads show page simultaneously.

Added new route for crossroads show page, link also setup to the page in the navbar dropdown collection of links.

Basic CSS setup for the modal along with a button for showing the specific crossroad.

Modal controller generated and basic JS code for it setup.

Crossroads modal page setup with a button and dialog for showing the subsequent show specific crossroad details.