### PR TITLE
Duplicate Crossroad Route Removed

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,6 @@
 
 require 'sidekiq/web'
 Rails.application.routes.draw do
-  get 'crossroads/show'
   get 'static_pages/home'
   mount Sidekiq::Web => '/sidekiq'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
Crossroads route generated from Rails command to setup the initial crossroad files and code has been removed as a more specific route to the crossroads show page has been specified elsewhere in the routes file since.