### PR TITLE
Unconfirmed Emails Accounted For. Users Edit, Update and Destroy also Implemented

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -16,6 +16,10 @@ module Authentication
     reset_session
   end
 
+  def authenticate_user!
+    redirect_to login_path, alert: "You need to login to access that page." unless user_signed_in?
+  end
+
   def redirect_if_authenticated
     redirect_to root_path, alert: "You are already logged in." if user_signed_in?
   end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,6 +1,6 @@
 class ConfirmationsController < ApplicationController
   before_action :redirect_if_authenticated, only: [:create, :new]
-  
+
   def create
     @user = User.find_by(email: params[:user][:email].downcase)
 
@@ -16,11 +16,11 @@ class ConfirmationsController < ApplicationController
     @user = User.find_signed(params[:confirmation_token], purpose: :confirm_email)
 
     if @user.present?
-      @user.confirm!
-      redirect_to root_path, notice: "Your account has been confirmed."
-      login @user
+      if @user.confirm!
+        login @user
+        redirect_to root_path, notice: "Your account has been confirmed."
     else
-      redirect_to new_confirmation_path, alert: "Invalid token."
+        redirect_to new_confirmation_path, alert: "Something is not correct."
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController # rubocop:todo Style/Documentation
-  before_action :redirect_if_authenticated, only: [:create, :new]
-  
+  before_action :authenticate_user!, only: [:edit, :destroy, :update]
+
   def index
     @users = User.all
   end
@@ -12,7 +12,7 @@ class UsersController < ApplicationController # rubocop:todo Style/Documentation
   end
 
   def create
-    @user = User.new(user_params)
+    @user = User.new(create_user_params)
     UserMailer.with(user: @user).welcome_email
 
     # UserInsertionWorker.perform_async(users)
@@ -28,7 +28,44 @@ class UsersController < ApplicationController # rubocop:todo Style/Documentation
     end
   end
 
+  def destroy
+    current_user.destroy
+    reset_session
+    redirect_to root_path, notice: "Your account has been deleted."
+  end
+
+  def edit
+    @user = current_user
+  end
+
+  def update
+    @user = current_user
+    if @user.authenticate(params[:user][:current_password])
+      if @user.update(update_user_params)
+        if params[:user][:unconfirmed_email].present?
+          @user.send_confirmation_email!
+          redirect_to root_path, notice: "Check your email for confirmation instructions."
+        else
+          redirect_to root_path, notice: "Account updated."
+        end
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    else
+      flash.now[:error] = "Incorrect password"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
+
+  def create_user_params
+    params.require(:user).permit(:email, :password, :password_confirmation)
+  end
+
+  def update_user_params
+    params.require(:user).permit(:current_password, :password, :password_confirmation, :unconfirmed_email)
+  end
 
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,6 +11,10 @@ class UserMailer < ApplicationMailer # rubocop:todo Style/Documentation
     mail(to: @user.email, subject: 'Welcome to Rails Junction')
   end
 
+  def confirmation(user, confirmation_token)
+    mail to: @user.confirmable_email, subject: "Confirmation Instructions"
+  end
+
   def password_reset(user, password_reset_token)
     @user = user
     @password_reset_token = password_reset_token

--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |type, msg| %>
+  <div class="alert alert-<%= type %>">
+    <%= msg %>
+  </div>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,25 @@
+<%= simple_form_for @user, url: account_path, method: :put do |form| %>
+  <%= render partial: "shared/form_errors", locals: { object: form.object } %>
+  <div>
+    <%= form.label :email, "Current Email" %>
+    <%= form.email_field :email, disabled: true %>
+  </div>
+  <div>
+    <%= form.label :unconfirmed_email, "New Email" %>
+    <%= form.input_field :unconfirmed_email %>
+  </div>
+  <div>
+    <%= form.label :password, "Password (leave blank if you don't want to change it)" %>
+    <%= form.input_field :password %>
+  </div>
+  <div>
+    <%= form.label :password_confirmation %>
+    <%= form.input_field :password_confirmation %>
+  </div>
+  <hr/>
+  <div>
+    <%= form.label :current_password, "Current password (we need your current password to confirm your changes)" %>
+    <%= form.input_field :current_password, required: true %>
+  </div>
+  <%= form.button :submit, "Update Account" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,9 @@ Rails.application.routes.draw do
 
   post "sign_up", to: "users#create"
   get "sign_up", to: "users#new"
+  put "account", to: "users#update"
+  get "account", to: "users#edit"
+  delete "account", to: "users#destroy"
 
   post "login", to: "sessions#create"
   delete "logout", to: "sessions#destroy"

--- a/db/migrate/20240317121123_add_unconfirmed_email_to_users.rb
+++ b/db/migrate/20240317121123_add_unconfirmed_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddUnconfirmedEmailToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :unconfirmed_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_16_213824) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_17_121123) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -65,6 +65,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_16_213824) do
     t.string "email"
     t.string "password_digest"
     t.string "password_confirmation"
+    t.string "unconfirmed_email"
   end
 
   add_foreign_key "junctions", "cities"


### PR DESCRIPTION
Various methods for unconfirmed users have been added to the user model to determine and differentiate if a user is trying to access with an email that is signed up but not authenticated, therefore the non authenticated email is stored and cannot be attempted repeatedly.

Updated the confirmations controller edit method to take into account if the user account has been confirmed or not which determines the path that they will be taken on.

Authentication module updated with a authenticate user method for if they are authenticated or not.

User controller added edit, destroy and update actions for users wishing to complete any of these actions for their accounts. Also setup a Simple Form edit user account page.

Also updated the routes to account for the three new user account actions.

New user mailed method also added giving confirmation instructions to the user signing up if not yet confirmed.

Migration file added via Rails generate command and migrated into the DB for unconfirmed emails for users.