### PR TITLE
Remember User Aspect Inserted, DB Updated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem "strong_migrations"
 # JavaScript/Ruby charts for junctions and cities
 gem "chartkick"
 
-# To group and view by day, week, specific day hour etc. 
+# To group and view by day, week, specific day hour etc.
 gem "groupdate"
 
 group :development, :test do

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -16,6 +16,16 @@ module Authentication
     reset_session
   end
 
+  def forget(user)
+    cookies.delete :remember_token
+    user.regenerate_remember_token
+  end
+
+  def remember(user)
+    user.regenerate_remember_token
+    cookies.permanent.encrypted[:remember_token] = user.remember_token
+  end
+
   def authenticate_user!
     redirect_to login_path, alert: "You need to login to access that page." unless user_signed_in?
   end
@@ -27,7 +37,11 @@ module Authentication
   private
 
   def current_user
-    Current.user ||= session[:current_user_id] && User.find_by(id: session[:current_user_id])
+    Current.user ||= if session[:current_user_id].present?
+      User.find_by(id: session[:current_user_id])
+    elsif cookies.permanent.encrypted[:remember_token].present?
+      User.find_by(remember_token: cookies.permanent.encrypted[:remember_token])
+    end
   end
 
   def user_signed_in?

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -15,7 +15,7 @@ class ConfirmationsController < ApplicationController
   def edit
     @user = User.find_signed(params[:confirmation_token], purpose: :confirm_email)
 
-    if @user.present?
+    if @user.present? && @user.unconfirmed_or_reconfirming?
       if @user.confirm!
         login @user
         redirect_to root_path, notice: "Your account has been confirmed."

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < ApplicationController
   before_action :redirect_if_authenticated, only: [:create, :new]
+  before_action :authenticate_user!, only: [:destroy]
 
   def create
     @user = User.find_by(email: params[:user][:email].downcase)
@@ -9,6 +10,7 @@ class SessionsController < ApplicationController
       elsif @user.authenticate(params[:user][:password])
         login @user
         redirect_to root_path, notice: "Signed in."
+        remember(@user) if params[:user][:remember_me] == "1"
       else
         flash.now[:alert] = "Incorrect email or password."
         render :new, status: :unprocessable_entity
@@ -20,6 +22,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
+    forget(current_user)
     logout
     redirect_to root_path, notice: "Signed out."
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord # rubocop:todo Style/Documentation
   PASSWORD_RESET_TOKEN_EXPIRATION = 10.minutes
 
   has_secure_password
+  has_secure_token :remember_token
   validates :name, presence: true, uniqueness: true
   validates :unconfirmed_email, format: { with: URI::MailTo::EMAIL_REGEXP}, presence: true, uniqueness: true
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,5 +1,9 @@
 <%= simple_form_for :user, url: login_path do |form| %>
   <%= form.input :email, required: true, label: "Email" %>
   <%= form.input :password, required: true, label: "Password" %>
+  <div>
+    <%= form.label :remember_me %>
+    <%= form.check_box :remember_me %>
+  </div>
   <%= form.button :submit, "Sign In" %>
 <% end %>

--- a/db/migrate/20240319193858_add_remember_token_to_users.rb
+++ b/db/migrate/20240319193858_add_remember_token_to_users.rb
@@ -1,0 +1,8 @@
+class AddRememberTokenToUsers < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+  
+  def change
+    add_column :users, :remember_token, :string, null: false
+    add_index :users, :remember_token, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_17_121123) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_19_193858) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -66,6 +66,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_17_121123) do
     t.string "password_digest"
     t.string "password_confirmation"
     t.string "unconfirmed_email"
+    t.string "remember_token", null: false
+    t.index ["remember_token"], name: "index_users_on_remember_token", unique: true
   end
 
   add_foreign_key "junctions", "cities"


### PR DESCRIPTION
User model updated with new secure remember_token.

Updated the authentication module with remember user helper methods.

Create and destroy sessions actions updated to account for remembering and forgetting the specifically current user. Also callback action on authenticating the user will be for current users to use the destroy action to confirm their log out and for that to occur successfully. 

Used disable_ddl_transaction to disable the transaction wrapping the migration which was preventing the migration without using it, then successfully ran the migration into the DB.

Gemfile showing as modified due to experimenting DB migration attempts with new migration file with and without strong_migrations gem active.