### PR TITLE
Geocoding Gem Setup, Creating Records Successfully Locally

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,9 @@ gem "chartkick"
 # To group and view by day, week, specific day hour etc.
 gem "groupdate"
 
+# For locating information and coordinates for junctions, cities etc.
+gem "geocoder"
+
 group :development, :test do
   gem 'ffaker'
   gem 'rubocop' # rubocop:todo Bundler/DuplicatedGem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
     ffaker (2.23.0)
     ffi (1.16.3)
     foreman (0.87.2)
+    geocoder (1.8.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     groupdate (6.4.0)
@@ -327,6 +328,7 @@ DEPENDENCIES
   debug
   ffaker
   foreman
+  geocoder
   groupdate
   importmap-rails
   jbuilder

--- a/app/models/junction.rb
+++ b/app/models/junction.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 class Junction < ApplicationRecord # rubocop:todo Style/Documentation
+  include Geocoder
+
   broadcasts_refreshes
   belongs_to :city
   has_many :posts
 
   attribute :junction
   attribute :location
+  attribute :address
+
+  geocoded_by :address
 end

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  # lookup: :nominatim,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  # api_key: nil,               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)

--- a/db/migrate/20240320193238_add_coordinates_to_junctions.rb
+++ b/db/migrate/20240320193238_add_coordinates_to_junctions.rb
@@ -1,0 +1,6 @@
+class AddCoordinatesToJunctions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :junctions, :latitude, :float
+    add_column :junctions, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_19_193858) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_20_193238) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -47,6 +47,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_193858) do
     t.string "difficulty"
     t.string "location"
     t.bigint "city_id", null: false
+    t.float "latitude"
+    t.float "longitude"
     t.index ["city_id"], name: "index_junctions_on_city_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,15 +43,23 @@ if last_city
     { name: 'Akihabara Crossing', location: 'Tokyo' }
   ]
 
+
   junctions_data.each do |junction_data|
     junction = last_city.junctions.create(junction_data)
 
     if junction.persisted?
       puts "Junction created successfully for the last city: #{last_city.name}"
+    # puts "Latitude: #{junction.latitude}, Longitude: #{junction.longitude}"
     else
       puts "Error creating junction - #{junction.errors.full_messages.join(', ')}"
     end
   end
 else
   puts 'No cities found. Please create some cities first.'
+end
+
+if junction.geocoding_error.present?
+  puts "Geocoding Error: #{junction.geocoding_error}"
+else
+  puts "Geocoding Successful!"
 end


### PR DESCRIPTION
Installed the latest version (1.8.2) of the geocoder gem following added it to the Gemfile. Gem also configured to use miles unit of length.

Geocoder gem setup due to relevance to the subject area, holds value with it being able to locate the precise coordinates of a specific location and/or city.

Added new Junctions migration file with new columns specific to geocoder, migrated these into the DB schema and also updated the Junction model with inclusion of Geocoder values, including an address attribute for geocoder functionality.

Rails console allows Junction create queries to be ran.

Also added to the pre-existing seed file conditional statement describing what is put if the seed process is successful.

A new method conditional statement has been setup also in the seed file for what should be put if the geocoding aspect of the seeding is unsuccessful, along with a short else conditional display message if it is successful.