### PR TITLE
Updated README.md to Reflect RSpec's Influence on Ruby Versions Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 ### Open plan application currently based around junctions (as the name suggests), locations and cities. Plan to integrate some graph functionality later down the line of development.
 
-#### Using GitHub Actions to assess the application against workflow jobs per each push into the repository. Build and bundler-audit jobs passing, working on passing matrix for different Ruby versions.
+#### Using GitHub Actions to assess the application against workflow jobs per each push into the repository. Build and bundler-audit jobs passing, various different Ruby versions matrix now passing due to new RSpec setup.


### PR DESCRIPTION
Updated README to reflect RSpec overtaking the test aspect of GitHub Actions now RSpec is setup within the application, accounting for every Ruby versions test check now passing.